### PR TITLE
Ghc 8.4 Compatibility

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,8 @@
 # Revision history for canonical-json
 
+## 0.5.0.1 2018-04-26
+* ghc-8.4 compatibility.
+
 ## 0.5.0.0 2017-09-06
 
 * Canonical JSON code extracted from hackage-security-0.5.2.2 into

--- a/Text/JSON/Canonical/Parse.hs
+++ b/Text/JSON/Canonical/Parse.hs
@@ -30,6 +30,9 @@ import qualified Text.PrettyPrint as Doc
 #if !(MIN_VERSION_base(4,8,0))
 import Control.Applicative ((<$>), (<$), pure, (<*>), (<*), (*>))
 #endif
+#if MIN_VERSION_base(4,11,0)
+import Prelude hiding ((<>))
+#endif
 import Data.Char (isDigit, digitToInt)
 import Data.Function (on)
 import Data.List (foldl', sortBy)

--- a/canonical-json.cabal
+++ b/canonical-json.cabal
@@ -1,5 +1,5 @@
 name:                canonical-json
-version:             0.5.0.0
+version:             0.5.0.1
 synopsis:            Canonical JSON for signing and hashing JSON values
 description:         An implementation of Canonical JSON.
                      .


### PR DESCRIPTION
This hides `<>` from the Prelude for ghc8.4+, to solve the following error:
```
        Ambiguous occurrence ‘<>’
        It could refer to either ‘Prelude.<>’,
                                 imported from ‘Prelude’ at Text/JSON/Canonical/Parse.hs:16:8-32
                                 (and originally defined in ‘GHC.Base’)
                              or ‘Doc.<>’,
                                 imported from ‘Text.PrettyPrint’ at Text/JSON/Canonical/Parse.hs:28:1-37
                                 (and originally defined in ‘Text.PrettyPrint.HughesPJ’)
```