### PR TITLE
Add Nix support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Cabal building
+dist/*
+dist-newstyle/*
+.ghc.environment.*
+

--- a/canonical-json.nix
+++ b/canonical-json.nix
@@ -1,0 +1,13 @@
+{ mkDerivation, base, bytestring, containers, parsec, pretty
+, stdenv
+}:
+mkDerivation {
+  pname = "canonical-json";
+  version = "0.5.0.0";
+  src = ./.;
+  libraryHaskellDepends = [
+    base bytestring containers parsec pretty
+  ];
+  description = "Canonical JSON for signing and hashing JSON values";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/fetch-nixpkgs.nix
+++ b/fetch-nixpkgs.nix
@@ -1,0 +1,6 @@
+let
+  spec = builtins.fromJSON (builtins.readFile ./nixpkgs-src.json);
+in builtins.fetchTarball {
+  url = "https://github.com/${spec.owner}/${spec.repo}/archive/${spec.rev}.tar.gz";
+  inherit (spec) sha256;
+}

--- a/nixpkgs-src.json
+++ b/nixpkgs-src.json
@@ -1,0 +1,6 @@
+{
+  "owner": "NixOS",
+  "repo": "nixpkgs",
+  "rev": "069bf7aee30faf7b3ed773cfae2154d761b2d6c2",
+  "sha256": "1c44vjb60fw2r8ck8yqwkj1w4288wixi59c6w1vazjixa79mvjvg"
+}

--- a/release.nix
+++ b/release.nix
@@ -1,0 +1,18 @@
+let
+  config = {
+    packageOverrides = pkgs: rec {
+      haskellPackages = pkgs.haskell.packages.ghc822.override {
+        overrides = haskellPackagesNew: haskellPackagesOld: rec {
+          canonical-json  = haskellPackagesNew.callPackage ./canonical-json.nix { };
+        };
+      };
+    };
+  };
+
+  # pinning
+  fetchNixPkgs  = import ./fetch-nixpkgs.nix;
+  pkgs          = import fetchNixPkgs { inherit config; };
+
+in
+  { canonical-json = pkgs.haskellPackages.canonical-json;
+  }

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,1 @@
+(import ./release.nix).canonical-json.env


### PR DESCRIPTION
Adding Nix support, since we run some issues when importing https://github.com/input-output-hk/cardano-prelude due to this dependency.
It would also be very nice if we could get this up on Hackage.