### PR TITLE
 Reduce stack usage in Map FromJSON instance #2

### DIFF
--- a/canonical-json.cabal
+++ b/canonical-json.cabal
@@ -55,6 +55,7 @@ test-suite tests
   build-depends:       base,
                        bytestring,
                        canonical-json,
+                       containers,
                        aeson             == 1.4.*,
                        vector,
                        unordered-containers,
@@ -62,4 +63,5 @@ test-suite tests
                        tasty,
                        tasty-quickcheck
   default-language:    Haskell2010
-  ghc-options:         -Wall
+  -- -K100k to check for stack overflow:
+  ghc-options:         -Wall -with-rtsopts=-K100k


### PR DESCRIPTION
Builds on PR #5 and covers more cases and adds tests, including tests that we run in constant stack space.

Interestingly the pretty-printing tests do not use constant stack space. But these are less important.